### PR TITLE
Add shared annotations anchoring logic

### DIFF
--- a/ts/annotations/anchoring/LICENSE
+++ b/ts/annotations/anchoring/LICENSE
@@ -1,0 +1,47 @@
+For the files range.coffee, util.coffee, and xpath.coffee:
+
+ Copyright 2015, the Annotator project contributors.
+ Copyright 2017 World Brain (@ worldbrain.io)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+For the files html.coffee, pdf.coffee, and types.coffee:
+
+ Copyright (c) 2013-2019 Hypothes.is Project and contributors
+ Copyright 2017 World Brain (@ worldbrain.io)
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ts/annotations/anchoring/html.coffee
+++ b/ts/annotations/anchoring/html.coffee
@@ -1,0 +1,98 @@
+{
+  FragmentAnchor
+  RangeAnchor
+  TextPositionAnchor
+  TextQuoteAnchor
+} = require('./types')
+
+
+querySelector = (type, root, selector, options) ->
+  doQuery = (resolve, reject) ->
+    try
+      anchor = type.fromSelector(root, selector, options)
+      range = anchor.toRange(options)
+      resolve(range)
+    catch error
+      reject(error)
+  return new Promise(doQuery)
+
+
+###*
+# Anchor a set of selectors.
+#
+# This function converts a set of selectors into a document range.
+# It encapsulates the core anchoring algorithm, using the selectors alone or
+# in combination to establish the best anchor within the document.
+#
+# :param Element root: The root element of the anchoring context.
+# :param Array selectors: The selectors to try.
+# :param Object options: Options to pass to the anchor implementations.
+# :return: A Promise that resolves to a Range on success.
+# :rtype: Promise
+####
+exports.anchor = (root, selectors, options = {}) ->
+  # Selectors
+  fragment = null
+  position = null
+  quote = null
+  range = null
+
+  # Collect all the selectors
+  for selector in selectors ? []
+    switch selector.type
+      when 'FragmentSelector'
+        fragment = selector
+      when 'TextPositionSelector'
+        position = selector
+        options.hint = position.start  # TextQuoteAnchor hint
+      when 'TextQuoteSelector'
+        quote = selector
+      when 'RangeSelector'
+        range = selector
+
+  # Assert the quote matches the stored quote, if applicable
+  maybeAssertQuote = (range) ->
+    if quote?.exact? and range.toString() != quote.exact
+      throw new Error('quote mismatch')
+    else
+      return range
+
+  # From a default of failure, we build up catch clauses to try selectors in
+  # order, from simple to complex.
+  promise = Promise.reject('unable to anchor')
+
+  if quote?
+    promise = promise.catch ->
+      # Note: similarity of the quote is implied.
+      return querySelector(TextQuoteAnchor, root, quote, options)
+
+  if fragment?
+    promise = promise.catch ->
+      return querySelector(FragmentAnchor, root, fragment, options)
+      .then(maybeAssertQuote)
+
+  if range?
+    promise = promise.catch ->
+      return querySelector(RangeAnchor, root, range, options)
+      .then(maybeAssertQuote)
+
+  if position?
+    promise = promise.catch ->
+      return querySelector(TextPositionAnchor, root, position, options)
+      .then(maybeAssertQuote)
+
+
+  return promise
+
+
+exports.describe = (root, range, options = {}) ->
+  types = [FragmentAnchor, RangeAnchor, TextPositionAnchor, TextQuoteAnchor]
+
+  selectors = for type in types
+    try
+      anchor = type.fromRange(root, range, options)
+      selector = anchor.toSelector(options)
+    catch
+      continue
+
+  return selectors

--- a/ts/annotations/anchoring/pdf.coffee
+++ b/ts/annotations/anchoring/pdf.coffee
@@ -1,0 +1,316 @@
+seek = require('dom-seek')
+
+xpathRange = require('./range')
+
+html = require('./html')
+RenderingStates = require('../pdfjs-rendering-states')
+{TextPositionAnchor, TextQuoteAnchor} = require('./types')
+
+# Caches for performance
+
+# Map of page index to page text content as a `Promise<string>`
+pageTextCache = {}
+# Two-dimensional map from `[quote][position]` to `{page, anchor}` intended to
+# optimize re-anchoring of a pair of quote and position selectors if the
+# position selector fails to anchor on its own.
+quotePositionCache = {}
+
+
+getSiblingIndex = (node) ->
+  siblings = Array.prototype.slice.call(node.parentNode.childNodes)
+  return siblings.indexOf(node)
+
+
+getNodeTextLayer = (node) ->
+  until node.classList?.contains('page')
+    node = node.parentNode
+  return node.getElementsByClassName('textLayer')[0]
+
+
+getPage = (pageIndex) ->
+  return PDFViewerApplication.pdfViewer.getPageView(pageIndex)
+
+
+getPageTextContent = (pageIndex) ->
+  if pageTextCache[pageIndex]?
+    return pageTextCache[pageIndex]
+  else
+    joinItems = ({items}) ->
+      # Skip empty items since PDF-js leaves their text layer divs blank.
+      # Excluding them makes our measurements match the rendered text layer.
+      # Otherwise, the selectors we generate would not match this stored text.
+      # See the appendText method of TextLayerBuilder in pdf.js.
+      nonEmpty = (item.str for item in items when /\S/.test(item.str))
+      textContent = nonEmpty.join('')
+      return textContent
+
+    pageTextCache[pageIndex] = PDFViewerApplication.pdfViewer.getPageTextContent(pageIndex)
+    .then(joinItems)
+    return pageTextCache[pageIndex]
+
+
+# Return the offset in the text for the whole document at which the text for
+# `pageIndex` begins.
+getPageOffset = (pageIndex) ->
+  index = -1
+
+  next = (offset) ->
+    if ++index is pageIndex
+      return Promise.resolve(offset)
+
+    return getPageTextContent(index)
+    .then((textContent) -> next(offset + textContent.length))
+
+  return next(0)
+
+
+# Return an {index, offset, textContent} object for the page where the given
+# `offset` in the full text of the document occurs.
+findPage = (offset) ->
+  index = 0
+  total = 0
+
+  # We call `count` once for each page, in order. The passed offset is found on
+  # the first page where the cumulative length of the text content exceeds the
+  # offset value.
+  #
+  # When we find the page the offset is on, we return an object containing the
+  # page index, the offset at the start of that page, and the textContent of
+  # that page.
+  #
+  # To understand this a little better, here's a worked example. Imagine a
+  # document with the following page lengths:
+  #
+  #    Page 0 has length 100
+  #    Page 1 has length 50
+  #    Page 2 has length 50
+  #
+  # Then here are the pages that various offsets are found on:
+  #
+  #    offset | index
+  #    --------------
+  #    0      | 0
+  #    99     | 0
+  #    100    | 1
+  #    101    | 1
+  #    149    | 1
+  #    150    | 2
+  #
+  count = (textContent) ->
+    lastPageIndex = PDFViewerApplication.pdfViewer.pagesCount - 1
+    if total + textContent.length > offset or index == lastPageIndex
+      offset = total
+      return Promise.resolve({index, offset, textContent})
+    else
+      index++
+      total += textContent.length
+      return getPageTextContent(index).then(count)
+
+  return getPageTextContent(0).then(count)
+
+
+# Search for a position anchor within a page, creating a placeholder and
+# anchoring to that if the page is not rendered.
+anchorByPosition = (page, anchor, options) ->
+  renderingState = page.renderingState
+  renderingDone = page.textLayer?.renderingDone
+  if renderingState is RenderingStates.FINISHED and renderingDone
+    root = page.textLayer.textLayerDiv
+    selector = anchor.toSelector(options)
+    return html.anchor(root, [selector])
+  else
+    div = page.div ? page.el
+    placeholder = div.getElementsByClassName('annotator-placeholder')[0]
+    unless placeholder?
+      placeholder = document.createElement('span')
+      placeholder.classList.add('annotator-placeholder')
+      placeholder.textContent = 'Loading annotations…'
+      div.appendChild(placeholder)
+    range = document.createRange()
+    range.setStartBefore(placeholder)
+    range.setEndAfter(placeholder)
+    return range
+
+
+# Search for a quote (with optional position hint) in the given pages.
+# Returns a `Promise<Range>` for the location of the quote.
+findInPages = ([pageIndex, rest...], quote, position) ->
+  unless pageIndex?
+    return Promise.reject(new Error('Quote not found'))
+
+  attempt = (info) ->
+    # Try to find the quote in the current page.
+    [page, content, offset] = info
+    root = {textContent: content}
+    anchor = new TextQuoteAnchor.fromSelector(root, quote)
+    if position?
+      hint = position.start - offset
+      hint = Math.max(0, hint)
+      hint = Math.min(hint, content.length)
+      return anchor.toPositionAnchor({hint})
+    else
+      return anchor.toPositionAnchor()
+
+  next = ->
+    return findInPages(rest, quote, position)
+
+  cacheAndFinish = (anchor) ->
+    if position
+      quotePositionCache[quote.exact] ?= {}
+      quotePositionCache[quote.exact][position.start] = {page, anchor}
+    return anchorByPosition(page, anchor)
+
+  page = getPage(pageIndex)
+  content = getPageTextContent(pageIndex)
+  offset = getPageOffset(pageIndex)
+
+  return Promise.all([page, content, offset])
+  .then(attempt)
+  .then(cacheAndFinish)
+  .catch(next)
+
+
+# When a position anchor is available, quote search can prioritize pages by
+# the position, searching pages outward starting from the page containing the
+# expected offset. This should speed up anchoring by searching fewer pages.
+prioritizePages = (position) ->
+  {pagesCount} = PDFViewerApplication.pdfViewer
+  pageIndices = [0...pagesCount]
+
+  sort = (pageIndex) ->
+    left = pageIndices.slice(0, pageIndex)
+    right = pageIndices.slice(pageIndex)
+    result = []
+    while left.length or right.length
+      if right.length
+        result.push(right.shift())
+      if left.length
+        result.push(left.pop())
+    return result
+
+  if position?
+    return findPage(position.start)
+    .then(({index}) -> return sort(index))
+  else
+    return Promise.resolve(pageIndices)
+
+
+###*
+# Anchor a set of selectors.
+#
+# This function converts a set of selectors into a document range.
+# It encapsulates the core anchoring algorithm, using the selectors alone or
+# in combination to establish the best anchor within the document.
+#
+# :param Element root: The root element of the anchoring context.
+# :param Array selectors: The selectors to try.
+# :param Object options: Options to pass to the anchor implementations.
+# :return: A Promise that resolves to a Range on success.
+# :rtype: Promise
+####
+exports.anchor = (root, selectors, options = {}) ->
+  # Selectors
+  position = null
+  quote = null
+
+  # Collect all the selectors
+  for selector in selectors ? []
+    switch selector.type
+      when 'TextPositionSelector'
+        position = selector
+      when 'TextQuoteSelector'
+        quote = selector
+
+  # Until we successfully anchor, we fail.
+  promise = Promise.reject('unable to anchor')
+
+  # Assert the quote matches the stored quote, if applicable
+  assertQuote = (range) ->
+    if quote?.exact? and range.toString() != quote.exact
+      throw new Error('quote mismatch')
+    else
+      return range
+
+  if position?
+    promise = promise.catch ->
+      return findPage(position.start)
+      .then ({index, offset, textContent}) ->
+        page = getPage(index)
+        start = position.start - offset
+        end = position.end - offset
+        length = end - start
+        assertQuote(textContent.substr(start, length))
+        anchor = new TextPositionAnchor(root, start, end)
+        return anchorByPosition(page, anchor, options)
+
+  if quote?
+    promise = promise.catch ->
+      if position? and quotePositionCache[quote.exact]?[position.start]?
+        {page, anchor} = quotePositionCache[quote.exact][position.start]
+        return anchorByPosition(page, anchor, options)
+
+      return prioritizePages(position)
+      .then((pageIndices) -> findInPages(pageIndices, quote, position))
+
+  return promise
+
+
+###*
+# Convert a DOM Range object into a set of selectors.
+#
+# Converts a DOM `Range` object describing a start and end point within a
+# `root` `Element` and converts it to a `[position, quote]` tuple of selectors
+# which can be saved into an annotation and later passed to `anchor` to map
+# the selectors back to a `Range`.
+#
+# :param Element root: The root Element
+# :param Range range: DOM Range object
+# :param Object options: Options passed to `TextQuoteAnchor` and
+#                        `TextPositionAnchor`'s `toSelector` methods.
+###
+exports.describe = (root, range, options = {}) ->
+
+  range = new xpathRange.BrowserRange(range).normalize()
+
+  startTextLayer = getNodeTextLayer(range.start)
+  endTextLayer = getNodeTextLayer(range.end)
+
+  # XXX: range covers only one page
+  if startTextLayer isnt endTextLayer
+    throw new Error('selecting across page breaks is not supported')
+
+  startRange = range.limit(startTextLayer)
+  endRange = range.limit(endTextLayer)
+
+  startPageIndex = getSiblingIndex(startTextLayer.parentNode)
+  endPageIndex = getSiblingIndex(endTextLayer.parentNode)
+
+  iter = document.createNodeIterator(startTextLayer, NodeFilter.SHOW_TEXT)
+
+  start = seek(iter, range.start)
+  end = seek(iter, range.end) + start + range.end.textContent.length
+
+  return getPageOffset(startPageIndex).then (pageOffset) ->
+    # XXX: range covers only one page
+    start += pageOffset
+    end += pageOffset
+
+    position = new TextPositionAnchor(root, start, end).toSelector(options)
+
+    r = document.createRange()
+    r.setStartBefore(startRange.start)
+    r.setEndAfter(endRange.end)
+
+    quote = TextQuoteAnchor.fromRange(root, r, options).toSelector(options)
+
+    return Promise.all([position, quote])
+
+
+###*
+# Clear the internal caches of page text contents and quote locations.
+#
+# This exists mainly as a helper for use in tests.
+###
+exports.purgeCache = ->
+  pageTextCache = {}
+  quotePositionCache = {}

--- a/ts/annotations/anchoring/range.coffee
+++ b/ts/annotations/anchoring/range.coffee
@@ -1,0 +1,472 @@
+$ = require('jquery')
+
+Util = require('./util')
+
+Range = {}
+
+# Public: Determines the type of Range of the provided object and returns
+# a suitable Range instance.
+#
+# r - A range Object.
+#
+# Examples
+#
+#   selection = window.getSelection()
+#   Range.sniff(selection.getRangeAt(0))
+#   # => Returns a BrowserRange instance.
+#
+# Returns a Range object or false.
+Range.sniff = (r) ->
+  if r.commonAncestorContainer?
+    new Range.BrowserRange(r)
+  else if typeof r.start is "string"
+    new Range.SerializedRange(r)
+  else if r.start and typeof r.start is "object"
+    new Range.NormalizedRange(r)
+  else
+    console.error("MEMEX: Could not sniff range type")
+    false
+
+
+# Public: Finds an Element Node using an XPath relative to the document root.
+#
+# If the document is served as application/xhtml+xml it will try and resolve
+# any namespaces within the XPath.
+#
+# xpath - An XPath String to query.
+#
+# Examples
+#
+#   node = Range.nodeFromXPath('/html/body/div/p[2]')
+#   if node
+#     # Do something with the node.
+#
+# Returns the Node if found otherwise null.
+Range.nodeFromXPath = (xpath, root=document) ->
+  evaluateXPath = (xp, nsResolver=null) ->
+    try
+      document.evaluate('.' + xp, root, nsResolver, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
+    catch exception
+      # There are cases when the evaluation fails, because the
+      # HTML documents contains nodes with invalid names,
+      # for example tags with equal signs in them, or something like that.
+      # In these cases, the XPath expressions will have these abominations,
+      # too, and then they can not be evaluated.
+      # In these cases, we get an XPathException, with error code 52.
+      # See http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathException
+      # This does not necessarily make any sense, but this what we see
+      # happening.
+      console.log "MEMEX: XPath evaluation failed."
+      console.log "MEMEX: Trying fallback..."
+      # We have a an 'evaluator' for the really simple expressions that
+      # should work for the simple expressions we generate.
+      Util.nodeFromXPath(xp, root)
+
+  if not $.isXMLDoc document.documentElement
+    evaluateXPath xpath
+  else
+    # We're in an XML document, create a namespace resolver function to try
+    # and resolve any namespaces in the current document.
+    # https://developer.mozilla.org/en/DOM/document.createNSResolver
+    customResolver = document.createNSResolver(
+      if document.ownerDocument == null
+        document.documentElement
+      else
+        document.ownerDocument.documentElement
+    )
+    node = evaluateXPath xpath, customResolver
+
+    unless node
+      # If the previous search failed to find a node then we must try to
+      # provide a custom namespace resolver to take into account the default
+      # namespace. We also prefix all node names with a custom xhtml namespace
+      # eg. 'div' => 'xhtml:div'.
+      xpath = (for segment in xpath.split '/'
+        if segment and segment.indexOf(':') == -1
+          segment.replace(/^([a-z]+)/, 'xhtml:$1')
+        else segment
+      ).join('/')
+
+      # Find the default document namespace.
+      namespace = document.lookupNamespaceURI null
+
+      # Try and resolve the namespace, first seeing if it is an xhtml node
+      # otherwise check the head attributes.
+      customResolver  = (ns) ->
+        if ns == 'xhtml' then namespace
+        else document.documentElement.getAttribute('xmlns:' + ns)
+
+      node = evaluateXPath xpath, customResolver
+    node
+
+class Range.RangeError extends Error
+  constructor: (@type, @message, @parent=null) ->
+    superArg = -> @message
+    super superArg
+
+# Public: Creates a wrapper around a range object obtained from a DOMSelection.
+class Range.BrowserRange
+
+  # Public: Creates an instance of BrowserRange.
+  #
+  # object - A range object obtained via DOMSelection#getRangeAt().
+  #
+  # Examples
+  #
+  #   selection = window.getSelection()
+  #   range = new Range.BrowserRange(selection.getRangeAt(0))
+  #
+  # Returns an instance of BrowserRange.
+  constructor: (obj) ->
+    @commonAncestorContainer = obj.commonAncestorContainer
+    @startContainer          = obj.startContainer
+    @startOffset             = obj.startOffset
+    @endContainer            = obj.endContainer
+    @endOffset               = obj.endOffset
+
+  # Public: normalize works around the fact that browsers don't generate
+  # ranges/selections in a consistent manner. Some (Safari) will create
+  # ranges that have (say) a textNode startContainer and elementNode
+  # endContainer. Others (Firefox) seem to only ever generate
+  # textNode/textNode or elementNode/elementNode pairs.
+  #
+  # Returns an instance of Range.NormalizedRange
+  normalize: (root) ->
+    if @tainted
+      console.error("MEMEX: You may only call normalize() once on a BrowserRange!")
+      return false
+    else
+      @tainted = true
+
+    r = {}
+
+    # Look at the start
+    if @startContainer.nodeType is Node.ELEMENT_NODE
+      # We are dealing with element nodes
+      if @startOffset < @startContainer.childNodes.length
+        r.start = Util.getFirstTextNodeNotBefore @startContainer.childNodes[@startOffset]
+      else
+        r.start = Util.getFirstTextNodeNotBefore @startContainer
+      r.startOffset = 0
+    else
+      # We are dealing with simple text nodes
+      r.start = @startContainer
+      r.startOffset = @startOffset
+
+    # Look at the end
+    if @endContainer.nodeType is Node.ELEMENT_NODE
+      # Get specified node.
+      node = @endContainer.childNodes[@endOffset]
+
+      if node? # Does that node exist?
+        # Look for a text node either at the immediate beginning of node
+        n = node
+        while n? and (n.nodeType isnt Node.TEXT_NODE)
+          n = n.firstChild
+        if n? # Did we find a text node at the start of this element?
+          r.end = n
+          r.endOffset = 0
+
+      unless r.end?
+        # We need to find a text node in the previous sibling of the node at the
+        # given offset, if one exists, or in the previous sibling of its container.
+        if @endOffset
+          node = @endContainer.childNodes[@endOffset - 1]
+        else
+          node = @endContainer.previousSibling
+        r.end = Util.getLastTextNodeUpTo node
+        r.endOffset = r.end.nodeValue.length
+
+    else # We are dealing with simple text nodes
+      r.end = @endContainer
+      r.endOffset = @endOffset
+
+    # We have collected the initial data.
+
+    # Now let's start to slice & dice the text elements!
+    nr = {}
+
+    if r.startOffset > 0
+      # Do we really have to cut?
+      if !r.start.nextSibling || r.start.nodeValue.length > r.startOffset
+        # Yes. Cut.
+        nr.start = r.start.splitText(r.startOffset)
+      else
+        # Avoid splitting off zero-length pieces.
+        nr.start = r.start.nextSibling
+    else
+      nr.start = r.start
+
+    # is the whole selection inside one text element ?
+    if r.start is r.end
+      if nr.start.nodeValue.length > (r.endOffset - r.startOffset)
+        nr.start.splitText(r.endOffset - r.startOffset)
+      nr.end = nr.start
+    else # no, the end of the selection is in a separate text element
+      # does the end need to be cut?
+      if r.end.nodeValue.length > r.endOffset
+        r.end.splitText(r.endOffset)
+      nr.end = r.end
+
+    # Make sure the common ancestor is an element node.
+    nr.commonAncestor = @commonAncestorContainer
+    while nr.commonAncestor.nodeType isnt Node.ELEMENT_NODE
+      nr.commonAncestor = nr.commonAncestor.parentNode
+
+    new Range.NormalizedRange(nr)
+
+  # Public: Creates a range suitable for storage.
+  #
+  # root           - A root Element from which to anchor the serialisation.
+  # ignoreSelector - A selector String of elements to ignore. For example
+  #                  elements injected by the annotator.
+  #
+  # Returns an instance of SerializedRange.
+  serialize: (root, ignoreSelector) ->
+    this.normalize(root).serialize(root, ignoreSelector)
+
+# Public: A normalised range is most commonly used throughout the annotator.
+# its the result of a deserialised SerializedRange or a BrowserRange with
+# out browser inconsistencies.
+class Range.NormalizedRange
+
+  # Public: Creates an instance of a NormalizedRange.
+  #
+  # This is usually created by calling the .normalize() method on one of the
+  # other Range classes rather than manually.
+  #
+  # obj - An Object literal. Should have the following properties.
+  #       commonAncestor: A Element that encompasses both the start and end nodes
+  #       start:          The first TextNode in the range.
+  #       end             The last TextNode in the range.
+  #
+  # Returns an instance of NormalizedRange.
+  constructor: (obj) ->
+    @commonAncestor = obj.commonAncestor
+    @start          = obj.start
+    @end            = obj.end
+
+  # Public: For API consistency.
+  #
+  # Returns itself.
+  normalize: (root) ->
+    this
+
+  # Public: Limits the nodes within the NormalizedRange to those contained
+  # withing the bounds parameter. It returns an updated range with all
+  # properties updated. NOTE: Method returns null if all nodes fall outside
+  # of the bounds.
+  #
+  # bounds - An Element to limit the range to.
+  #
+  # Returns updated self or null.
+  limit: (bounds) ->
+    nodes = $.grep this.textNodes(), (node) ->
+      node.parentNode == bounds or $.contains(bounds, node.parentNode)
+
+    return null unless nodes.length
+
+    @start = nodes[0]
+    @end   = nodes[nodes.length - 1]
+
+    startParents = $(@start).parents()
+    for parent in $(@end).parents()
+      if startParents.index(parent) != -1
+        @commonAncestor = parent
+        break
+    this
+
+  # Convert this range into an object consisting of two pairs of (xpath,
+  # character offset), which can be easily stored in a database.
+  #
+  # root -           The root Element relative to which XPaths should be calculated
+  # ignoreSelector - A selector String of elements to ignore. For example
+  #                  elements injected by the annotator.
+  #
+  # Returns an instance of SerializedRange.
+  serialize: (root, ignoreSelector) ->
+
+    serialization = (node, isEnd) ->
+      if ignoreSelector
+        origParent = $(node).parents(":not(#{ignoreSelector})").eq(0)
+      else
+        origParent = $(node).parent()
+
+      xpath = Util.xpathFromNode(origParent, root)[0]
+      textNodes = Util.getTextNodes(origParent)
+
+      # Calculate real offset as the combined length of all the
+      # preceding textNode siblings. We include the length of the
+      # node if it's the end node.
+      nodes = textNodes.slice(0, textNodes.index(node))
+      offset = 0
+      for n in nodes
+        offset += n.nodeValue.length
+
+      if isEnd then [xpath, offset + node.nodeValue.length] else [xpath, offset]
+
+    start = serialization(@start)
+    end   = serialization(@end, true)
+
+    new Range.SerializedRange({
+      # XPath strings
+      start: start[0]
+      end: end[0]
+      # Character offsets (integer)
+      startOffset: start[1]
+      endOffset: end[1]
+    })
+
+  # Public: Creates a concatenated String of the contents of all the text nodes
+  # within the range.
+  #
+  # Returns a String.
+  text: ->
+    (for node in this.textNodes()
+      node.nodeValue
+    ).join ''
+
+  # Public: Fetches only the text nodes within th range.
+  #
+  # Returns an Array of TextNode instances.
+  textNodes: ->
+    textNodes = Util.getTextNodes($(this.commonAncestor))
+    [start, end] = [textNodes.index(this.start), textNodes.index(this.end)]
+    # Return the textNodes that fall between the start and end indexes.
+    $.makeArray textNodes[start..end]
+
+  # Public: Converts the Normalized range to a native browser range.
+  #
+  # See: https://developer.mozilla.org/en/DOM/range
+  #
+  # Examples
+  #
+  #   selection = window.getSelection()
+  #   selection.removeAllRanges()
+  #   selection.addRange(normedRange.toRange())
+  #
+  # Returns a Range object.
+  toRange: ->
+    range = document.createRange()
+    range.setStartBefore(@start)
+    range.setEndAfter(@end)
+    range
+
+# Public: A range suitable for storing in local storage or serializing to JSON.
+class Range.SerializedRange
+
+  # Public: Creates a SerializedRange
+  #
+  # obj - The stored object. It should have the following properties.
+  #       start:       An xpath to the Element containing the first TextNode
+  #                    relative to the root Element.
+  #       startOffset: The offset to the start of the selection from obj.start.
+  #       end:         An xpath to the Element containing the last TextNode
+  #                    relative to the root Element.
+  #       startOffset: The offset to the end of the selection from obj.end.
+  #
+  # Returns an instance of SerializedRange
+  constructor: (obj) ->
+    @start       = obj.start
+    @startOffset = obj.startOffset
+    @end         = obj.end
+    @endOffset   = obj.endOffset
+
+  # Public: Creates a NormalizedRange.
+  #
+  # root - The root Element from which the XPaths were generated.
+  #
+  # Returns a NormalizedRange instance.
+  normalize: (root) ->
+    range = {}
+
+    for p in ['start', 'end']
+      try
+        node = Range.nodeFromXPath(this[p], root)
+      catch e
+        throw new Range.RangeError(p, "Error while finding #{p} node: #{this[p]}: " + e, e)
+
+      if not node
+        throw new Range.RangeError(p, "Couldn't find #{p} node: #{this[p]}")
+
+      # Unfortunately, we *can't* guarantee only one textNode per
+      # elementNode, so we have to walk along the element's textNodes until
+      # the combined length of the textNodes to that point exceeds or
+      # matches the value of the offset.
+      length = 0
+      targetOffset = this[p + 'Offset']
+
+      # Range excludes its endpoint because it describes the boundary position.
+      # Target the string index of the last character inside the range.
+      if p is 'end' then targetOffset--
+
+      for tn in Util.getTextNodes($(node))
+        if (length + tn.nodeValue.length > targetOffset)
+          range[p + 'Container'] = tn
+          range[p + 'Offset'] = this[p + 'Offset'] - length
+          break
+        else
+          length += tn.nodeValue.length
+
+      # If we fall off the end of the for loop without having set
+      # 'startOffset'/'endOffset', the element has shorter content than when
+      # we annotated, so throw an error:
+      if not range[p + 'Offset']?
+        throw new Range.RangeError("#{p}offset", "Couldn't find offset #{this[p + 'Offset']} in element #{this[p]}")
+
+    # Here's an elegant next step...
+    #
+    #   range.commonAncestorContainer = $(range.startContainer).parents().has(range.endContainer)[0]
+    #
+    # ...but unfortunately Node.contains() is broken in Safari 5.1.5 (7534.55.3)
+    # and presumably other earlier versions of WebKit. In particular, in a
+    # document like
+    #
+    #   <p>Hello</p>
+    #
+    # the code
+    #
+    #   p = document.getElementsByTagName('p')[0]
+    #   p.contains(p.firstChild)
+    #
+    # returns `false`. Yay.
+    #
+    # So instead, we step through the parents from the bottom up and use
+    # Node.compareDocumentPosition() to decide when to set the
+    # commonAncestorContainer and bail out.
+
+    contains =
+      if not document.compareDocumentPosition?
+        # IE
+        (a, b) -> a.contains(b)
+      else
+        # Everyone else
+        (a, b) -> a.compareDocumentPosition(b) & 16
+
+    $(range.startContainer).parents().each ->
+      if contains(this, range.endContainer)
+        range.commonAncestorContainer = this
+        return false
+
+    new Range.BrowserRange(range).normalize(root)
+
+  # Public: Creates a range suitable for storage.
+  #
+  # root           - A root Element from which to anchor the serialisation.
+  # ignoreSelector - A selector String of elements to ignore. For example
+  #                  elements injected by the annotator.
+  #
+  # Returns an instance of SerializedRange.
+  serialize: (root, ignoreSelector) ->
+    this.normalize(root).serialize(root, ignoreSelector)
+
+  # Public: Returns the range as an Object literal.
+  toObject: ->
+    {
+      start: @start
+      startOffset: @startOffset
+      end: @end
+      endOffset: @endOffset
+    }
+
+module.exports = Range

--- a/ts/annotations/anchoring/types.coffee
+++ b/ts/annotations/anchoring/types.coffee
@@ -1,0 +1,127 @@
+# This module exports a set of classes for converting between DOM `Range`
+# objects and different types of selector. It is mostly a thin wrapper around a
+# set of anchoring libraries. It serves two main purposes:
+#
+#  1. Providing a consistent interface across different types of anchor.
+#  2. Insulating the rest of the code from API changes in the underyling anchoring
+#     libraries.
+
+domAnchorTextPosition = require('dom-anchor-text-position')
+domAnchorTextQuote = require('dom-anchor-text-quote')
+
+xpathRange = require('./range')
+
+# Helper function for throwing common errors
+missingParameter = (name) ->
+  throw new Error('missing required parameter "' + name + '"')
+
+
+###*
+# class:: RangeAnchor(range)
+#
+# This anchor type represents a DOM Range.
+#
+# :param Range range: A range describing the anchor.
+###
+class RangeAnchor
+  constructor: (root, range) ->
+    unless root? then missingParameter('root')
+    unless range? then missingParameter('range')
+    @root = root
+    @range = xpathRange.sniff(range).normalize(@root)
+
+  @fromRange: (root, range) ->
+    return new RangeAnchor(root, range)
+
+  # Create and anchor using the saved Range selector.
+  @fromSelector: (root, selector) ->
+    data = {
+      start: selector.startContainer
+      startOffset: selector.startOffset
+      end: selector.endContainer
+      endOffset: selector.endOffset
+    }
+    range = new xpathRange.SerializedRange(data)
+    return new RangeAnchor(root, range)
+
+  toRange: () ->
+    return @range.toRange()
+
+  toSelector: (options = {}) ->
+    range = @range.serialize(@root, options.ignoreSelector)
+    return {
+      type: 'RangeSelector'
+      startContainer: range.start
+      startOffset: range.startOffset
+      endContainer: range.end
+      endOffset: range.endOffset
+    }
+
+###*
+# Converts between TextPositionSelector selectors and Range objects.
+###
+class TextPositionAnchor
+  constructor: (root, start, end) ->
+    @root = root
+    @start = start
+    @end = end
+
+  @fromRange: (root, range) ->
+    selector = domAnchorTextPosition.fromRange(root, range)
+    TextPositionAnchor.fromSelector(root, selector)
+
+  @fromSelector: (root, selector) ->
+    new TextPositionAnchor(root, selector.start, selector.end)
+
+  toSelector: () ->
+    {
+      type: 'TextPositionSelector',
+      start: @start,
+      end: @end,
+    }
+
+  toRange: () ->
+    domAnchorTextPosition.toRange(@root, {start: @start, end: @end})
+
+###*
+# Converts between TextQuoteSelector selectors and Range objects.
+###
+class TextQuoteAnchor
+  constructor: (root, exact, context = {}) ->
+    @root = root
+    @exact = exact
+    @context = context
+
+  @fromRange: (root, range, options) ->
+    selector = domAnchorTextQuote.fromRange(root, range, options)
+    TextQuoteAnchor.fromSelector(root, selector)
+
+  @fromSelector: (root, selector) ->
+    {prefix, suffix} = selector
+    new TextQuoteAnchor(root, selector.exact, {prefix, suffix})
+
+  toSelector: () ->
+    {
+      type: 'TextQuoteSelector',
+      exact: @exact,
+      prefix: @context.prefix,
+      suffix: @context.suffix,
+    }
+
+  toRange: (options = {}) ->
+    range = domAnchorTextQuote.toRange(@root, this.toSelector(), options)
+    if range == null
+      throw new Error('Quote not found')
+    range
+
+  toPositionAnchor: (options = {}) ->
+    anchor = domAnchorTextQuote.toTextPosition(@root, this.toSelector(), options)
+    if anchor == null
+      throw new Error('Quote not found')
+    new TextPositionAnchor(@root, anchor.start, anchor.end)
+
+
+exports.RangeAnchor = RangeAnchor
+exports.FragmentAnchor = require('dom-anchor-fragment')
+exports.TextPositionAnchor = TextPositionAnchor
+exports.TextQuoteAnchor = TextQuoteAnchor

--- a/ts/annotations/anchoring/util.coffee
+++ b/ts/annotations/anchoring/util.coffee
@@ -1,0 +1,109 @@
+$ = require('jquery')
+
+{ simpleXPathJQuery, simpleXPathPure } = require('./xpath')
+
+Util = {}
+
+# Public: Flatten a nested array structure
+#
+# Returns an array
+Util.flatten = (array) ->
+  flatten = (ary) ->
+    flat = []
+
+    for el in ary
+      flat = flat.concat(if el and $.isArray(el) then flatten(el) else el)
+
+    return flat
+
+  flatten(array)
+
+# Public: Finds all text nodes within the elements in the current collection.
+#
+# Returns a new jQuery collection of text nodes.
+Util.getTextNodes = (jq) ->
+  getTextNodes = (node) ->
+    if node and node.nodeType != Node.TEXT_NODE
+      nodes = []
+
+      # If not a comment then traverse children collecting text nodes.
+      # We traverse the child nodes manually rather than using the .childNodes
+      # property because IE9 does not update the .childNodes property after
+      # .splitText() is called on a child text node.
+      if node.nodeType != Node.COMMENT_NODE
+        # Start at the last child and walk backwards through siblings.
+        node = node.lastChild
+        while node
+          nodes.push getTextNodes(node)
+          node = node.previousSibling
+
+      # Finally reverse the array so that nodes are in the correct order.
+      return nodes.reverse()
+    else
+      return node
+
+  jq.map -> Util.flatten(getTextNodes(this))
+
+# Public: determine the last text node inside or before the given node
+Util.getLastTextNodeUpTo = (n) ->
+  switch n.nodeType
+    when Node.TEXT_NODE
+      return n # We have found our text node.
+    when Node.ELEMENT_NODE
+      # This is an element, we need to dig in
+      if n.lastChild? # Does it have children at all?
+        result = Util.getLastTextNodeUpTo n.lastChild
+        if result? then return result
+    else
+      # Not a text node, and not an element node.
+  # Could not find a text node in current node, go backwards
+  n = n.previousSibling
+  if n?
+    Util.getLastTextNodeUpTo n
+  else
+    null
+
+# Public: determine the first text node in or after the given jQuery node.
+Util.getFirstTextNodeNotBefore = (n) ->
+  switch n.nodeType
+    when Node.TEXT_NODE
+      return n # We have found our text node.
+    when Node.ELEMENT_NODE
+      # This is an element, we need to dig in
+      if n.firstChild? # Does it have children at all?
+        result = Util.getFirstTextNodeNotBefore n.firstChild
+        if result? then return result
+    else
+      # Not a text or an element node.
+  # Could not find a text node in current node, go forward
+  n = n.nextSibling
+  if n?
+    Util.getFirstTextNodeNotBefore n
+  else
+    null
+
+Util.xpathFromNode = (el, relativeRoot) ->
+  try
+    result = simpleXPathJQuery.call el, relativeRoot
+  catch exception
+    console.log "MEMEX: jQuery-based XPath construction failed! Falling back to manual."
+    result = simpleXPathPure.call el, relativeRoot
+  result
+
+Util.nodeFromXPath = (xp, root) ->
+  steps = xp.substring(1).split("/")
+  node = root
+  for step in steps
+    [name, idx] = step.split "["
+    idx = if idx? then parseInt (idx?.split "]")[0] else 1
+    node = findChild node, name.toLowerCase(), idx
+
+  node
+
+module.exports = {
+  nodeFromXPath: Util.nodeFromXPath,
+  xpathFromNode: Util.xpathFromNode,
+  getTextNodes: Util.getTextNodes,
+  getFirstTextNodeNotBefore: Util.getFirstTextNodeNotBefore,
+  getLastTextNodeUpTo: Util.getLastTextNodeUpTo,
+}

--- a/ts/annotations/anchoring/xpath.coffee
+++ b/ts/annotations/anchoring/xpath.coffee
@@ -1,0 +1,85 @@
+$ = require('jquery')
+
+# A simple XPath evaluator using jQuery which can evaluate queries of
+simpleXPathJQuery = (relativeRoot) ->
+  jq = this.map ->
+    path = ''
+    elem = this
+
+    while elem?.nodeType == Node.ELEMENT_NODE and elem isnt relativeRoot
+      tagName = elem.tagName.replace(":", "\\:")
+      idx = $(elem.parentNode).children(tagName).index(elem) + 1
+
+      idx  = "[#{idx}]"
+      path = "/" + elem.tagName.toLowerCase() + idx + path
+      elem = elem.parentNode
+
+    path
+
+  jq.get()
+
+# A simple XPath evaluator using only standard DOM methods which can
+# evaluate queries of the form /tag[index]/tag[index].
+simpleXPathPure = (relativeRoot) ->
+
+  getPathSegment = (node) ->
+    name = getNodeName node
+    pos = getNodePosition node
+    "#{name}[#{pos}]"
+
+  rootNode = relativeRoot
+
+  getPathTo = (node) ->
+    xpath = '';
+    while node != rootNode
+      unless node?
+        throw new Error "Called getPathTo on a node which was not a descendant of @rootNode. " + rootNode
+      xpath = (getPathSegment node) + '/' + xpath
+      node = node.parentNode
+    xpath = '/' + xpath
+    xpath = xpath.replace /\/$/, ''
+    xpath
+
+  jq = this.map ->
+    path = getPathTo this
+
+    path
+
+  jq.get()
+
+findChild = (node, type, index) ->
+  unless node.hasChildNodes()
+    throw new Error "XPath error: node has no children!"
+  children = node.childNodes
+  found = 0
+  for child in children
+    name = getNodeName child
+    if name is type
+      found += 1
+      if found is index
+        return child
+  throw new Error "XPath error: wanted child not found."
+
+# Get the node name for use in generating an xpath expression.
+getNodeName = (node) ->
+    nodeName = node.nodeName.toLowerCase()
+    switch nodeName
+      when "#text" then return "text()"
+      when "#comment" then return "comment()"
+      when "#cdata-section" then return "cdata-section()"
+      else return nodeName
+
+# Get the index of the node as it appears in its parent's child list
+getNodePosition = (node) ->
+  pos = 0
+  tmp = node
+  while tmp
+    if tmp.nodeName is node.nodeName
+      pos++
+    tmp = tmp.previousSibling
+  pos
+
+module.exports = {
+  simpleXPathJQuery,
+  simpleXPathPure,
+}

--- a/ts/annotations/highlight-dom-range.ts
+++ b/ts/annotations/highlight-dom-range.ts
@@ -1,0 +1,227 @@
+/**
+ * Custom implementation of `dom-highlight-range`.
+ * The original implementation is available here: https://github.com/Treora/dom-highlight-range
+ *
+ * This implementation does not make use of `span` tag for highlighting the text
+ * in a range. Instead, it uses a custom `memex-highlight` tag. This ensures
+ * that the CSS for highlighting does not bleed too much into the host site.
+ * Also, unlike the original implementation, tables are handled properly.
+ */
+
+// Wrap each text node in a given DOM Range with a <memex-highlight class=[highLightClass]>.
+// Breaks start and/or end node if needed.
+// Returns a function that cleans up the created highlight (not a perfect undo: split text nodes are not merged again).
+//
+// Parameters:
+// - rangeObject: a Range whose start and end containers are text nodes.
+// - highlightClass: the CSS class the text pieces in the range should get, defaults to 'highlighted-range'.
+export const highlightDOMRange = (
+    rangeObject: Range,
+    highlightClass: string,
+) => {
+    // Ignore range if empty.
+    if (rangeObject.collapsed) {
+        return
+    }
+
+    if (typeof highlightClass === 'undefined') {
+        highlightClass = 'highlighted-range'
+    }
+
+    // First put all nodes in an array (splits start and end nodes)
+    const nodes: Node[] = textNodesInRange(rangeObject)
+
+    // Remember range details to restore it later.
+    const { startContainer, startOffset, endContainer, endOffset } = rangeObject
+
+    // Highlight each node
+    // const highlights: HTMLElement[] =
+    nodes.forEach(node => highlightNode(node, highlightClass))
+
+    // Reset selection
+    clearBrowserSelection()
+
+    // The rangeObject gets messed up by our DOM changes. Be kind and restore.
+    rangeObject.setStart(startContainer, startOffset)
+    rangeObject.setEnd(endContainer, endOffset)
+}
+
+// Resets any selected content in the window, useful to stop content script popping up again inconsistently.
+const clearBrowserSelection = () => {
+    if (window.getSelection) {
+        if (window.getSelection()?.empty) {
+            // Chrome
+            window.getSelection()?.empty()
+        } else if (window.getSelection()?.removeAllRanges) {
+            // Firefox
+            window.getSelection()?.removeAllRanges()
+        }
+    } else if ((document as any)['selection']) {
+        // IE
+        ;(document as any)['selection'].empty()
+    }
+}
+
+// Return an array of the text nodes in the range. Split the start and end nodes if required.
+// Maybe change the type of rangeObject to `Range` in the future. Currently,
+// doing so breaks the usage of some properties/methods like `length` and
+// `splitText()` on `startContainer`.
+const textNodesInRange = (rangeObject: any) => {
+    // Modify Range to make sure that the start and end nodes are text nodes.
+    setRangeToTextNodes(rangeObject)
+
+    // Ignore range if empty.
+    if (rangeObject.collapsed) {
+        return []
+    }
+
+    // Include (part of) the start node if needed.
+    if (rangeObject.startOffset !== rangeObject.startContainer.length) {
+        // If only part of the start node is in the range, split it.
+        if (rangeObject.startOffset !== 0) {
+            // Split startContainer to turn the part after the startOffset into a new node.
+            const createdNode: Text = rangeObject.startContainer.splitText(
+                rangeObject.startOffset,
+            )
+
+            // If the end was in the same container, it will now be in the newly created node.
+            if (rangeObject.endContainer === rangeObject.startContainer) {
+                rangeObject.setEnd(
+                    createdNode,
+                    rangeObject.endOffset - rangeObject.startOffset,
+                )
+            }
+
+            // Update the start node, which no longer has an offset.
+            rangeObject.setStart(createdNode, 0)
+        }
+    }
+
+    // Find the root for the range object.
+    const root: Node =
+        typeof rangeObject.commonAncestorContainer !== 'undefined'
+            ? rangeObject.commonAncestorContainer
+            : document.body // fall back to whole document for browser compatibility
+
+    // Create an iterator to iterate through the nodes.
+    // Type should be `NodeIterator` but doing so breaks the usage of
+    // `iter.referenceNode` for some reason.
+    const iter: any = document.createNodeIterator(root, NodeFilter.SHOW_TEXT)
+
+    // Find the start node (could we somehow skip this seemingly needless search?)
+    while (
+        iter.referenceNode !== rangeObject.startContainer &&
+        iter.referenceNode !== null
+    ) {
+        iter.nextNode()
+    }
+
+    // Regex for checking against whitespace.
+    const whiteSpace: RegExp = /^\s*$/
+    const nodes: Node[] = []
+
+    // Add each node up to (but excluding) the end node.
+    while (
+        iter.referenceNode !== rangeObject.endContainer &&
+        iter.referenceNode !== null
+    ) {
+        // Don't push the nodes that consist entirely of whitespace.
+        if (!whiteSpace.test(iter.referenceNode.nodeValue)) {
+            nodes.push(iter.referenceNode)
+        }
+        iter.nextNode()
+    }
+
+    // Include (part of) the end node if needed.
+    if (rangeObject.endOffset !== 0) {
+        // If it is only partly included, we need to split it up.
+        if (rangeObject.endOffset !== rangeObject.endContainer.length) {
+            // Split the node, breaking off the part outside the range.
+            rangeObject.endContainer.splitText(rangeObject.endOffset)
+            // Note that the range object need not be updated.
+
+            // assert(rangeObject.endOffset == rangeObject.endContainer.length);
+        }
+
+        // Add the end node.
+        nodes.push(rangeObject.endContainer)
+    }
+
+    return nodes
+}
+
+// Normalise the range to start and end in a text node.
+// Copyright (c) 2015 Randall Leeds
+const setRangeToTextNodes = (rangeObject: Range) => {
+    let startNode: Node = rangeObject.startContainer
+    let startOffset: number = rangeObject.startOffset
+
+    // Drill down to a text node if the range starts at the container boundary.
+    if (startNode.nodeType !== Node.TEXT_NODE) {
+        if (startOffset === startNode.childNodes.length) {
+            startNode = startNode.childNodes[startOffset - 1]
+            startNode = getFirstTextNode(startNode)!
+            startOffset = startNode.textContent!.length
+        } else {
+            startNode = startNode.childNodes[startOffset]
+            startNode = getFirstTextNode(startNode)!
+            startOffset = 0
+        }
+        rangeObject.setStart(startNode, startOffset)
+    }
+
+    let endNode: Node = rangeObject.endContainer
+    let endOffset: number = rangeObject.endOffset
+
+    // Drill down to a text node if the range ends at the container boundary.
+    if (endNode.nodeType !== Node.TEXT_NODE) {
+        if (endOffset === endNode.childNodes.length) {
+            endNode = endNode.childNodes[endOffset - 1]
+            endNode = getFirstTextNode(endNode)!
+            endOffset = endNode.textContent!.length
+        } else {
+            endNode = endNode.childNodes[endOffset]
+            endNode = getFirstTextNode(endNode)!
+            endOffset = 0
+        }
+        rangeObject.setEnd(endNode, endOffset)
+    }
+}
+
+// Gets first text node inside a node.
+const getFirstTextNode = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+        return node
+    }
+    const document: Document = node.ownerDocument!
+    const walker: TreeWalker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_TEXT,
+        null,
+        false,
+    )
+    return walker.firstChild()
+}
+
+// Replace [node] with <memex-highlight class=[highlightClass]>[node]</memex-highlight>
+const highlightNode = (node: Node, highlightClass: string) => {
+    // Create a highlight
+    const highlight: HTMLElement = document.createElement('memex-highlight')
+    highlight.classList.add(highlightClass)
+
+    // Wrap it around the text node
+    node.parentNode?.replaceChild(highlight, node)
+    highlight.appendChild(node)
+
+    return highlight
+}
+
+// Remove a highlight <memex-highlight> created with highlightNode.
+const removeHighlight = (highlight: HTMLElement) => {
+    // Move its children (normally just one text node) into its parent.
+    while (highlight.firstChild) {
+        highlight.parentNode?.insertBefore(highlight.firstChild, highlight)
+    }
+    // Remove the now empty node
+    highlight.remove()
+}

--- a/ts/annotations/index.js
+++ b/ts/annotations/index.js
@@ -1,0 +1,68 @@
+import * as domTextQuote from 'dom-anchor-text-quote'
+import * as domTextPosition from 'dom-anchor-text-position'
+import * as hypAnchoring from './anchoring/html'
+import { highlightDOMRange } from './highlight-dom-range'
+
+export async function selectionToDescriptor({ selection }) {
+    if (selection === null || selection.isCollapsed) {
+        return null
+    }
+
+    const range = selection.getRangeAt(0)
+    const root = document.body
+    return {
+        strategy: 'hyp-anchoring',
+        content: hypAnchoring.describe(root, range),
+    }
+}
+
+export async function descriptorToRange({ descriptor }) {
+    const root = document.body
+    if (descriptor.strategy === 'dom-anchor-text-quote') {
+        return domTextQuote.toRange(root, descriptor.content)
+    }
+    if (descriptor.strategy === 'hyp-anchoring') {
+        return hypAnchoring.anchor(root, descriptor.content)
+    }
+
+    const rangeFromQuote = domTextQuote.toRange(
+        root,
+        descriptor.content.textQuote,
+    )
+    if (!rangeFromQuote) {
+        return null
+    }
+    if (
+        !hasAncestor(
+            rangeFromQuote.commonAncestorContainer,
+            node => node.tagName && node.tagName.toLowerCase() === 'script',
+        )
+    ) {
+        return rangeFromQuote
+    }
+
+    const rangeFromPosition = domTextPosition.toRange(root, descriptor.content)
+    if (!rangeFromPosition) {
+        return null
+    }
+    if (rangeFromPosition.toString() === descriptor.content.string) {
+        return rangeFromPosition
+    }
+
+    return null
+}
+
+export function markRange({ range, cssClass }) {
+    return highlightDOMRange(range, cssClass)
+}
+
+function hasAncestor(node, test) {
+    while (node !== document.body) {
+        if (test(node)) {
+            return true
+        }
+        node = node.parentNode
+    }
+
+    return false
+}

--- a/ts/storage/constants.ts
+++ b/ts/storage/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Pattern to match hashtag prefix syntax for tags.
+ * NOTE: Please update these together if they change.
+ */
+export const HASH_TAG_PATTERN = /^-?#\w+([-\.]\w+)*$/
+export const VALID_TAG_PATTERN = /^\w+([-\.]\w+)*$/


### PR DESCRIPTION
- brings across annotations anchoring logic used by the annotations features in both memex ext + Go
- relevant to ongoing Memex ext reader work from @cdharris in https://github.com/WorldBrain/Memex/pull/1028 (not yet updated to use this)
- relevant to ongoing Memex Go reader work in https://github.com/WorldBrain/Memex-Mobile/pull/29 (already updated to use this)

Things I am unsure about:
1. This is the first non-TS code in this repo - contains coffeescript + JS. Though I put it under the `ts/` dir, which seems to be the dir all source code goes under. Regardless of what that dir is named it should all work fine once the builds are updated, though this may be a point of confusion somewhere down the track.