### PR TITLE
Extra font key for styling external content

### DIFF
--- a/ts/common-ui/styles/types.ts
+++ b/ts/common-ui/styles/types.ts
@@ -9,7 +9,7 @@ export type ColorThemeKeys =
   | 'grey'
   | 'black'
 
-export type FontThemeKeys = 'primary' | 'secondary'
+export type FontThemeKeys = 'primary' | 'secondary' | 'content'
 
 export type FontSizeThemeKeys = 'listTitle' | 'url'
 


### PR DESCRIPTION

I feel there's a need for a unique font style for displaying external content (like annotations) with high readability and clearly distinguishing them from the application. Hence adding this 'content' type to the theme spec.

used in https://github.com/WorldBrain/Memex-Social/pull/9